### PR TITLE
fix: Resolved crashes from both latest refactors

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -2,9 +2,12 @@
 #include "AnimationLC.h"
 #include "CameraRC.h"
 #include "FactoriesFactory.h"
+#include "GuiEC.h"
+#include "GuiLabelC.h"
 #include "Loader.h"
 #include "OgreSDLContext.h"
 #include "PhysicsContext.h"
+#include "QuitButtonC.h"
 #include "RigidbodyPC.h"
 #include "Scene.h"
 #include "SleepEC.h"
@@ -52,6 +55,9 @@ void Game::initContext() {
     SoundListenerComponentFactoryRegisterGlobalVar.noop();
     SleepECFactoryRegisterGlobalVar.noop();
     AnimationLCFactoryRegisterGlobalVar.noop();
+    GuiComponentFactoryRegisterGlobalVar.noop();
+    GuiLabelComponentFactoryRegisterGlobalVar.noop();
+    QuitButtonComponentFactoryRegisterGlobalVar.noop();
 }
 
 // Reads the scenes and sets the first one

--- a/src/RigidbodyPC.cpp
+++ b/src/RigidbodyPC.cpp
@@ -74,9 +74,8 @@ bool RigidbodyPC::collidesWithEntity(Entity* other) const {
     btPointCollector gjkOutput;
 
     btGjkPairDetector convexConvex(
-        dynamic_cast<btConvexShape*>(body_->getCollisionShape()),
-        dynamic_cast<btConvexShape*>(
-            otherRigidBody->body_->getCollisionShape()),
+        static_cast<btConvexShape*>(body_->getCollisionShape()),
+        static_cast<btConvexShape*>(otherRigidBody->body_->getCollisionShape()),
         &sGjkSimplexSolver, &epaSolver);
 
     btGjkPairDetector::ClosestPointInput input;


### PR DESCRIPTION
Fixes bugs introduced in other PRs:

- #83: The collision shape does not inherit `btConvexShape`, therefore, the `dynamic_cast` was returning `nullptr`, resulting on errors.
- #84: The components were added, but not registered. This causes issues when importing them due to the dead code checker from MSBuild.

This changeset has been pushed directly from Mood's submodule locally, meaning they have been tested in a much larger environment than OTY's own "small test suite".

There are two bugs left to fix that are more complex:

1. `GuiEC.cpp` at line 72, when the mouse is outside the game (e.g. when you Alt + Tab), it throws `this->mMouse_ was 0xFFFFFFFFFFFFFFE7` (at `GuiComponent::checkEvent()` method).
1. CEGUI's mouse handler overrides SDL's, this causes bugs as MOOD's `OrientateToMouse.h` stops working.

cc @onaranjoUCM to fix both bugs.