### PR TITLE
Minor updates to pngrutil.c instances

### DIFF
--- a/deps/cegui-dependencies/src/FreeImage-3.15.0/Source/LibPNG/pngrutil.c
+++ b/deps/cegui-dependencies/src/FreeImage-3.15.0/Source/LibPNG/pngrutil.c
@@ -144,6 +144,23 @@ png_read_chunk_header(png_structp png_ptr)
    png_reset_crc(png_ptr);
    png_calculate_crc(png_ptr, png_ptr->chunk_name, 4);
 
+   //Addition: owencqueen, 03/28/2021
+   /* Check for too-large chunk length */
+   if (png_ptr->chunk_name != png_IDAT)
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif  
+      if (length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }     
+
    /* Check to see if chunk name is valid. */
    png_check_chunk_name(png_ptr, png_ptr->chunk_name);
 

--- a/deps/cegui-dependencies/src/libpng-1.4.7/pngrutil.c
+++ b/deps/cegui-dependencies/src/libpng-1.4.7/pngrutil.c
@@ -147,6 +147,23 @@ png_read_chunk_header(png_structp png_ptr)
    /* Check to see if chunk name is valid. */
    png_check_chunk_name(png_ptr, png_ptr->chunk_name);
 
+   //Addition: owencqueen, 03/28/2021
+   /* Check for too-large chunk length */
+   if (png_ptr->chunk_name != png_IDAT)
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif  
+      if (length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }     
+
 #ifdef PNG_IO_STATE_SUPPORTED
    /* It is unspecified how many I/O calls will be performed
     * during the serialization of the chunk data.


### PR DESCRIPTION
I have gone through and added some updates that were made in libpng's recent updates (starting in commit 347538efbdc21b8df684ebd92d37400b3ce85d55). These are minor changes that should provide capability for a user limit on the size of chunks of png files read.